### PR TITLE
chore: use `tsc --noEmit` for type checking

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,12 +13,6 @@
 		}
 	},
 	"formatter": {
-		"enabled": true,
-		"formatWithErrors": false,
-		"indentStyle": "tab",
-		"indentWidth": 2,
-		"lineWidth": 80,
-		"lineEnding": "lf",
-		"ignore": []
+		"enabled": true
 	}
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"workspaces": ["workers/*"],
 	"scripts": {
-		"lint": "biome lint --apply ./",
+		"lint": "biome lint --apply ./ && tsc --noEmit",
 		"format": "biome format --write ./",
 		"test": "vitest"
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"skipLibCheck": true,
 		"module": "es2022",
 		"target": "es2022",
 		"lib": ["es2021"],

--- a/workers/echo/test/index.spec.ts
+++ b/workers/echo/test/index.spec.ts
@@ -10,11 +10,7 @@ import worker, { type ResponseBody } from "../src";
 describe("Echo worker", () => {
 	it("get responds with 200 OK", async () => {
 		const request = new Request("http://example.com?pretty=true");
-		// Create an empty context to pass to `worker.fetch()`
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
+		const response = await worker.fetch(request);
 		expect(response.status).toBe(200);
 		const responseBody = (await response.json()) as ResponseBody;
 		expect(responseBody).toBeDefined();
@@ -31,11 +27,7 @@ describe("Echo worker", () => {
 			method: "POST",
 			body: JSON.stringify({ hello: "world" }),
 		});
-		// Create an empty context to pass to `worker.fetch()`
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
+		const response = await worker.fetch(request);
 		expect(response.status).toBe(200);
 		const responseBody = (await response.json()) as ResponseBody;
 		expect(responseBody).toBeDefined();

--- a/workers/hello-world/src/index.ts
+++ b/workers/hello-world/src/index.ts
@@ -1,9 +1,5 @@
 export default {
-	async fetch(
-		request: Request,
-		env: Env,
-		ctx: ExecutionContext,
-	): Promise<Response> {
+	async fetch(request: Request): Promise<Response> {
 		return new Response("Hello, World!");
 	},
 };

--- a/workers/hello-world/test/index.spec.ts
+++ b/workers/hello-world/test/index.spec.ts
@@ -10,11 +10,7 @@ import worker from "../src";
 describe("Echo worker", () => {
 	it("responds with 200 OK", async () => {
 		const request = new Request("http://example.com/");
-		// Create an empty context to pass to `worker.fetch()`
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
+		const response = await worker.fetch(request);
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe("Hello, World!");
 	});

--- a/workers/paste/src/index.ts
+++ b/workers/paste/src/index.ts
@@ -71,7 +71,6 @@ app.get("/pastes", async (c: Context<{ Bindings: Bindings }>) => {
 
 app.post("/pastes", async (c: Context<{ Bindings: Bindings }>) => {
 	const content_type = c.req.header("content-type");
-	console.log(c.req.url, c.req.headers);
 	const created_at = new Date().toISOString();
 	const expires_at = new Date(
 		Date.now() + 1000 * 60 * 60 * 24 * 7,

--- a/workers/paste/test/env.d.ts
+++ b/workers/paste/test/env.d.ts
@@ -1,6 +1,7 @@
 declare module "cloudflare:test" {
 	// Controls the type of `import("cloudflare:test").env`
 	interface ProvidedEnv extends Env {
+		DB: D1Database;
 		TEST_MIGRATIONS: D1Migration[]; // Defined in `vitest.config.ts`
 	}
 }

--- a/workers/tfstate/src/handlers.ts
+++ b/workers/tfstate/src/handlers.ts
@@ -1,4 +1,3 @@
-import type { RouteParams } from "./middlewares";
 import type { Env } from "./types/env";
 import type { RequestWithIdentity } from "./types/request";
 import type { LockInfo } from "./types/terraform";
@@ -12,7 +11,7 @@ import { getObjectKey } from "./utils";
  * @param env
  */
 export const getStateHandler = async (
-	request: RequestWithIdentity & RouteParams,
+	request: RequestWithIdentity,
 	env: Env,
 ) => {
 	const { projectName } = request;
@@ -38,7 +37,7 @@ export const getStateHandler = async (
  * @param env
  */
 export const putStateHandler = async (
-	request: RequestWithIdentity & RouteParams,
+	request: RequestWithIdentity,
 	env: Env,
 ) => {
 	const { projectName, url } = request;
@@ -75,7 +74,7 @@ export const putStateHandler = async (
  * @param env
  */
 export const deleteStateHandler = async (
-	request: RequestWithIdentity & RouteParams,
+	request: RequestWithIdentity,
 	env: Env,
 ) => {
 	const { projectName, url } = request;
@@ -106,7 +105,7 @@ export const deleteStateHandler = async (
  * @param request
  */
 export const lockStateHandler = async (
-	request: RequestWithIdentity & RouteParams,
+	request: RequestWithIdentity,
 	env: Env,
 ) => {
 	const { projectName } = request;

--- a/workers/tfstate/src/types/request.d.ts
+++ b/workers/tfstate/src/types/request.d.ts
@@ -1,9 +1,11 @@
+import type { IRequest } from "itty-router";
+
 export interface UserInfo {
 	username: string;
 	namespaceId?: string;
 }
 
-export interface RequestWithIdentity extends Request {
+export interface RequestWithIdentity extends IRequest {
 	identity?: {
 		userInfo?: UserInfo;
 	};


### PR DESCRIPTION
There were no typescript errors being reported in the CI, because `tsc` was not being run. Run `tsc --noEmit` in the CI to check for typescript errors.